### PR TITLE
Apply table name

### DIFF
--- a/index.js
+++ b/index.js
@@ -281,6 +281,11 @@ class ServerlessDynamodbLocal {
         const resources = _.get(stack, "Resources", []);
         return Object.keys(resources).map((key) => {
             if (resources[key].Type === "AWS::DynamoDB::Table") {
+                if (!resources[key].Properties.TableName) {
+                    const service = this.service.service;
+                    const stage = this.options.stage || this.service.provider.stage;
+                    resources[key].Properties.TableName = `${service}-${stage}-${key}`;
+                  }
                 return resources[key].Properties;
             }
         }).filter((n) => n);


### PR DESCRIPTION
When no table name is provided in serverless.yml, use the dynamic generated table name

Fixes issue #[Add issue number here. If you do not solve the issue entirely, please change the message e.g. "First steps for issues #IssueNumber]

Changes: [Add here what changes were made in this issue and if possible provide links.]

Demo Link: [Add here the link where your changes can be seen]

Screenshots for the change: 
